### PR TITLE
docker-composeでipdbが効くようにrun

### DIFF
--- a/bin/docker-compose-build-run.sh
+++ b/bin/docker-compose-build-run.sh
@@ -1,0 +1,2 @@
+docker-compose build
+docker-compose run --service-ports web


### PR DESCRIPTION
Ref: #5 

単純な`docker-compose up`では厳しいよう。upコマンドはそもそも対話コマンドに対応していない。
> https://github.com/docker/compose/issues/4677#issuecomment-320804194
> So yeah - for anyone doing interactive debugging, run is indeed the way to go. Fundamentally, up is not designed to address this use case, but this has nothing to do with exposing ports, and everything to do with up not being an interactive command by design.

よって、以下参考に
> https://gist.github.com/katylava/3559c29160573488a7bbccb474b55356

rebuildしてから、`docker-compose run --service-ports web`で対応。
